### PR TITLE
[feat] 게시글 조회 API 연동

### DIFF
--- a/src/components/ConcernCard.tsx
+++ b/src/components/ConcernCard.tsx
@@ -3,6 +3,7 @@ import { useResponsiveStore } from '../stores/useResponsiveStore';
 import clsx from 'clsx';
 
 interface ConcernCardProps {
+  id: number;
   profileImage: string;
   title: string;
   category: string;
@@ -13,16 +14,19 @@ interface ConcernCardProps {
   };
   date?: string;
   backgroundImage?: string;
+  onClick?: (id: number) => void;
 }
 
 const ConcernCard: React.FC<ConcernCardProps> = ({
+  id,
   profileImage,
   title,
   category,
   content,
   recentComment,
   date,
-  backgroundImage
+  backgroundImage,
+  onClick
 }) => {
   const res = useResponsiveStore((state) => state.res);
   const isMobile = res === 'mo';
@@ -36,7 +40,9 @@ const ConcernCard: React.FC<ConcernCardProps> = ({
       style={{
         backgroundImage: `url(${backgroundImage || '/images/ConcernBackground.png'})`,
         boxShadow: 'inset 0 0 0 2px #473C2C',
+        cursor: onClick ? 'pointer' : 'default',
       }}
+      onClick={() => onClick && onClick(id)}
     >
       <div className={clsx('relative z-10 w-full h-full px-[0.3125rem]')}>
         {/* 프로필 이미지 */}

--- a/src/components/ConcernPost.tsx
+++ b/src/components/ConcernPost.tsx
@@ -9,7 +9,19 @@ import PrevArrow from "../assets/images/PrevArrow.svg"
 import NextArrow from "../assets/images/NextArrow.svg"
 import { useParams } from 'react-router-dom';
 
-export const ConcernContent: React.FC = () => {
+interface ConcernContentProps {
+  title: string;
+  content: string;
+  category: string;
+  date: string;
+}
+
+export const ConcernContent: React.FC<ConcernContentProps> = ({
+  title,
+  content,
+  category,
+  date
+}) => {
   const { concern, toggleConcernLike } = useConcernDetailStore()
   const { comments } = useCommentStore()
   const getTotalCommentCount = (list: typeof comments): number =>
@@ -20,12 +32,12 @@ export const ConcernContent: React.FC = () => {
     <div className='flex items-center justify-center w-full'>
       <img src={PrevArrow} alt='이전 고민' />
       <div className='text-darkWalnut font-mainFont mx-2 bg-mainWhite h-auto w-4/5 rounded-[40px] p-[50px] pb-[32px] my-24 shadow-[0_2px_4px_rgba(0,0,0,0.25)]'>
-        <p className='text-[30px]'>{concern?.title}</p>
+        <p className='text-[30px]'>{title}</p>
         <div className='flex items-center my-[20px]'>
-          <img src={concern?.profileImage} alt='프로필이미지' className='w-[30px] h-[30px] rounded-[50%] mr-[12px]' />
-          <p className='text-[16px]'>{concern?.nickname}</p>
+          <img src="images/MoonRabbitLogo.png" alt='프로필이미지' className='w-[30px] h-[30px] rounded-[50%] mr-[12px]' />
+          <p className='text-[16px]'>달토끼</p>
         </div>
-        <p className='whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight'>{concern?.content}</p>
+        <p className='whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight'>{content}</p>
         <div className='flex mt-[60px] justify-between'>
           <div className='flex items-center'>
             <img src={Comment} alt='댓글아이콘' className='h-[24px]' />
@@ -35,7 +47,7 @@ export const ConcernContent: React.FC = () => {
               <img src={concern?.like ? Liked : Like} className='cursor-pointer h-[25px]'  />
             </div>
           </div>
-          <p>{concern?.date}</p>
+          <p>{date}</p>
         </div>
       </div>
       <img src={NextArrow} alt='다음 고민' />
@@ -43,12 +55,26 @@ export const ConcernContent: React.FC = () => {
   )
 }
 
-export const ConcernAnswer: React.FC = () => {
-  const { concern } = useConcernDetailStore()
+interface Answer {
+  userId: number;
+  boardId: number;
+  content: string;
+  createdAt: string;
+}
+
+interface ConcernAnswerProps {
+  answers: Answer[];
+}
+
+export const ConcernAnswer: React.FC<ConcernAnswerProps> = ({ answers }) => {
   return(
     <div className='text-darkWalnut font-mainFont bg-mainWhite h-auto w-4/5 rounded-[40px] p-[50px] shadow-[0_2px_4px_rgba(0,0,0,0.25)]'>
       <p className='text-[30px] mb-[20px]'>달토끼 답변</p>
-      <p className='whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight'>{concern?.answer}</p>
+      {answers.length > 0 ? (
+        <p className='whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight'>{answers[0].content}</p>
+      ) : (
+        <p className='whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight'>아직 답변이 없어요. 첫 답변을 남겨보세요!</p>
+      )}
     </div>
   )
 }

--- a/src/pages/NightSkyDetailPage.tsx
+++ b/src/pages/NightSkyDetailPage.tsx
@@ -1,13 +1,54 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { ConcernContent, ConcernAnswer } from '../components/ConcernPost';
 import { ConcernComment } from '../components/ConcernComment';
+import { useBoardDetailStore } from '../stores/useBoardDetailStore';
 
 const NightSkyDetailPage: React.FC = () => {
+  const { pageNumber } = useParams<{ pageNumber: string }>();
+  const { boardDetail, isLoading, error, fetchBoardDetail } = useBoardDetailStore();
+
+  useEffect(() => {
+    if (pageNumber) {
+      fetchBoardDetail(parseInt(pageNumber));
+    }
+  }, [pageNumber, fetchBoardDetail]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-xl text-gray-600">로딩 중...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-xl text-red-600">{error}</div>
+      </div>
+    );
+  }
+
+  if (!boardDetail) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-xl text-gray-600">게시글을 찾을 수 없습니다.</div>
+      </div>
+    );
+  }
   
   return (
-    <div className="flex flex-col items-center justify-center">
-      <ConcernContent />
-      <ConcernAnswer />
+    <div className="flex flex-col items-center justify-center w-full max-w-4xl mx-auto px-4 py-8">
+      <ConcernContent 
+        title={boardDetail.title}
+        content={boardDetail.content}
+        category={boardDetail.category}
+        date={new Date(boardDetail.answers[0]?.createdAt || new Date()).toISOString().split('T')[0]}
+      />
+      <ConcernAnswer 
+        answers={boardDetail.answers}
+      />
       <ConcernComment />
     </div>
   )

--- a/src/pages/NightSkyPage.tsx
+++ b/src/pages/NightSkyPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import CategoryBar from '../components/CategoryBar';
 import ConcernCard from '../components/ConcernCard';
 import CreateConcernButton from '../components/CreateConcernButton';
@@ -141,10 +141,15 @@ const NightSkyPage: React.FC = () => {
     setNewConcernTitle,
     setNewConcernContent,
     setNewConcernCategory,
-    resetForm
+    resetForm,
+    fetchConcerns
   } = useConcernStore();
 
   const { res } = useResponsiveStore();
+
+  useEffect(() => {
+    fetchConcerns();
+  }, [fetchConcerns]);
 
   const handleOpenModal = () => {
     setIsModalOpen(true);

--- a/src/pages/NightSkyPage.tsx
+++ b/src/pages/NightSkyPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import CategoryBar from '../components/CategoryBar';
 import ConcernCard from '../components/ConcernCard';
 import CreateConcernButton from '../components/CreateConcernButton';
@@ -146,6 +147,7 @@ const NightSkyPage: React.FC = () => {
   } = useConcernStore();
 
   const { res } = useResponsiveStore();
+  const navigate = useNavigate();
 
   useEffect(() => {
     fetchConcerns();
@@ -168,6 +170,10 @@ const NightSkyPage: React.FC = () => {
   // 모바일 뷰에서는 3개의 카드만 표시
   const displayConcerns = res === 'mo' ? filteredConcerns.slice(0, 3) : filteredConcerns;
 
+  const handleCardClick = (id: number) => {
+    navigate(`/night-sky/${id}`);
+  };
+
   return (
     <div className="w-full min-h-screen relative overflow-hidden">
       {/* 배경 이미지 div */}
@@ -189,7 +195,8 @@ const NightSkyPage: React.FC = () => {
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           {displayConcerns.map((concern, index) => (
             <ConcernCard
-              key={index}
+              key={concern.id}
+              id={concern.id}
               profileImage={concern.profileImage}
               title={concern.title}
               content={concern.content}
@@ -197,6 +204,7 @@ const NightSkyPage: React.FC = () => {
               recentComment={concern.recentComment}
               date={concern.date}
               backgroundImage={concern.backgroundImage}
+              onClick={handleCardClick}
             />
           ))}
         </div>

--- a/src/stores/useBoardDetailStore.ts
+++ b/src/stores/useBoardDetailStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand'
+import axios from 'axios'
+
+interface Answer {
+  userId: number;
+  boardId: number;
+  content: string;
+  createdAt: string;
+}
+
+interface BoardDetail {
+  userId: number;
+  title: string;
+  content: string;
+  category: string;
+  answers: Answer[];
+}
+
+interface BoardDetailStore {
+  boardDetail: BoardDetail | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchBoardDetail: (id: number) => Promise<void>;
+}
+
+export const useBoardDetailStore = create<BoardDetailStore>((set) => ({
+  boardDetail: null,
+  isLoading: false,
+  error: null,
+
+  fetchBoardDetail: async (id: number) => {
+    set({ isLoading: true, error: null });
+    try {
+      const response = await axios.get(`http://moonrabbit-api.kro.kr/api/boards/list/${id}`);
+      set({ 
+        boardDetail: response.data,
+        isLoading: false 
+      });
+    } catch (error) {
+      set({ 
+        error: '게시글을 불러오는데 실패했습니다.',
+        isLoading: false 
+      });
+      console.error('Failed to fetch board detail:', error);
+    }
+  }
+})) 

--- a/src/stores/useConcernStore.ts
+++ b/src/stores/useConcernStore.ts
@@ -1,4 +1,20 @@
 import { create } from 'zustand'
+import axios from 'axios'
+
+interface Answer {
+  userId: number;
+  boardId: number;
+  content: string;
+  createdAt: string;
+}
+
+interface Board {
+  userId: number;
+  title: string;
+  content: string;
+  category: string;
+  answers: Answer[];
+}
 
 interface Concern {
   id: number;
@@ -33,133 +49,34 @@ interface ConcernStore {
   setNewConcernContent: (content: string) => void;
   setNewConcernCategory: (category: string) => void;
   resetForm: () => void;
+  fetchConcerns: () => Promise<void>;
 }
 
-// 임시 데이터
-const initialConcerns: Concern[] = [
-  {
-    id: 1,
+const transformBoardToConcern = (board: Board): Concern => {
+  return {
+    id: board.userId,
     profileImage: 'images/MoonRabbitLogo.png',
-    title: '학교 생활이 힘들어요',
-    category: '학교',
-    content: '친구들과 잘 어울리지 못하고 있어요. 어떻게 하면 좋을까요?',
-    recentComment: {
-      author: '달토끼',
-      text: '천천히 친해져도 괜찮아요. 당신의 페이스대로 진행하세요.',
-    },
-    date: '2024-07-30',
+    title: board.title,
+    category: board.category,
+    content: board.content,
+    recentComment: board.answers.length > 0 
+      ? {
+          author: '달토끼',
+          text: board.answers[0].content,
+        }
+      : {
+          author: '달토끼',
+          text: '아직 답변이 없어요. 첫 답변을 남겨보세요!',
+        },
+    date: new Date(board.answers[0]?.createdAt || new Date()).toISOString().split('T')[0],
     backgroundImage: '/images/ConcernBackground.png',
-  },
-  {
-    id: 2,
-    profileImage: 'images/MoonRabbitLogo.png',
-    title: '취업 준비가 걱정돼요',
-    category: '진로',
-    content: '졸업을 앞두고 있는데, 취업 준비가 너무 걱정됩니다.',
-    recentComment: {
-      author: '달토끼',
-      text: '차근차근 준비하시면 좋은 결과가 있을 거예요.',
-    },
-    date: '2024-07-29',
-    backgroundImage: '/images/ConcernBackground.png',
-  },
-  {
-    id: 3,
-    profileImage: 'images/MoonRabbitLogo.png',
-    title: '가족 관계가 어려워요',
-    category: '가족',
-    content: '부모님과 자주 다투게 되고 있어요. 어떻게 대화해야 할지 모르겠어요.',
-    recentComment: {
-      author: '달토끼',
-      text: '서로의 입장을 이해하려 노력해보세요.',
-    },
-    date: '2024-07-28',
-    backgroundImage: '/images/ConcernBackground.png',
-  },
-  {
-    id: 4,
-    profileImage: 'images/MoonRabbitLogo.png',
-    title: '연인과의 관계가 불안해요',
-    category: '연인',
-    content: '서로의 미래가 불확실해서 걱정이에요. 어떻게 해야 할까요?',
-    recentComment: {
-      author: '달토끼',
-      text: '서로의 생각을 솔직하게 나누어보세요.',
-    },
-    date: '2024-07-27',
-    backgroundImage: '/images/ConcernBackground.png',
-  },
-  {
-    id: 5,
-    profileImage: 'images/MoonRabbitLogo.png',
-    title: '스트레스가 너무 심해요',
-    category: '정신건강',
-    content: '일과 공부로 인한 스트레스가 너무 심해요. 어떻게 해소해야 할까요?',
-    recentComment: {
-      author: '달토끼',
-      text: '충분한 휴식과 운동으로 스트레스를 해소해보세요.',
-    },
-    date: '2024-07-26',
-    backgroundImage: '/images/ConcernBackground.png',
-  },
-  {
-    id: 6,
-    profileImage: 'images/MoonRabbitLogo.png',
-    title: '직장 생활이 힘들어요',
-    category: '사회생활',
-    content: '직장에서의 인간관계가 어려워요. 어떻게 적응해야 할까요?',
-    recentComment: {
-      author: '달토끼',
-      text: '천천히 적응해도 괜찮아요. 당신의 페이스대로 진행하세요.',
-    },
-    date: '2024-07-25',
-    backgroundImage: '/images/ConcernBackground.png',
-  },
-  {
-    id: 7,
-    profileImage: 'images/MoonRabbitLogo.png',
-    title: '친구들과의 관계가 어색해요',
-    category: '대인관계',
-    content: '친구들과 만날 때마다 어색함이 느껴져요. 어떻게 해야 할까요?',
-    recentComment: {
-      author: '달토끼',
-      text: '자연스럽게 대화를 이어가보세요. 당신의 진정성이 전달될 거예요.',
-    },
-    date: '2024-07-24',
-    backgroundImage: '/images/ConcernBackground.png',
-  },
-  {
-    id: 8,
-    profileImage: 'images/MoonRabbitLogo.png',
-    title: '자신감이 부족해요',
-    category: '정신건강',
-    content: '무엇을 해도 자신감이 생기지 않아요. 어떻게 극복해야 할까요?',
-    recentComment: {
-      author: '달토끼',
-      text: '작은 성공부터 시작해보세요. 당신의 노력이 빛날 거예요.',
-    },
-    date: '2024-07-23',
-    backgroundImage: '/images/ConcernBackground.png',
-  },
-  {
-    id: 9,
-    profileImage: 'images/MoonRabbitLogo.png',
-    title: '미래가 불안해요',
-    category: '진로',
-    content: '앞으로의 삶이 어떻게 될지 모르겠어요. 어떻게 준비해야 할까요?',
-    recentComment: {
-      author: '달토끼',
-      text: '현재 할 수 있는 것부터 시작해보세요. 당신의 노력이 미래를 밝게 할 거예요.',
-    },
-    date: '2024-07-22',
-    backgroundImage: '/images/ConcernBackground.png',
-  },
-];
+  };
+};
 
 export const useConcernStore = create<ConcernStore>((set, get) => ({
-  concerns: initialConcerns,
+  concerns: [],
   selectedCategory: '전체',
-  filteredConcerns: initialConcerns,
+  filteredConcerns: [],
   isModalOpen: false,
   newConcernTitle: '',
   newConcernContent: '',
@@ -186,5 +103,20 @@ export const useConcernStore = create<ConcernStore>((set, get) => ({
     newConcernTitle: '',
     newConcernContent: '',
     newConcernCategory: '학교'
-  })
+  }),
+
+  fetchConcerns: async () => {
+    try {
+      const response = await axios.get('http://moonrabbit-api.kro.kr/api/boards/list');
+      const boards: Board[] = response.data;
+      const concerns = boards.map(transformBoardToConcern);
+      
+      set({ 
+        concerns,
+        filteredConcerns: concerns
+      });
+    } catch (error) {
+      console.error('Failed to fetch concerns:', error);
+    }
+  }
 })) 

--- a/src/stores/useConcernStore.ts
+++ b/src/stores/useConcernStore.ts
@@ -9,6 +9,7 @@ interface Answer {
 }
 
 interface Board {
+  boardId: number;
   userId: number;
   title: string;
   content: string;
@@ -54,7 +55,7 @@ interface ConcernStore {
 
 const transformBoardToConcern = (board: Board): Concern => {
   return {
-    id: board.userId,
+    id: board.boardId,
     profileImage: 'images/MoonRabbitLogo.png',
     title: board.title,
     category: board.category,
@@ -108,7 +109,7 @@ export const useConcernStore = create<ConcernStore>((set, get) => ({
   fetchConcerns: async () => {
     try {
       const response = await axios.get('http://moonrabbit-api.kro.kr/api/boards/list');
-      const boards: Board[] = response.data;
+      const boards: Board[] = response.data.content;
       const concerns = boards.map(transformBoardToConcern);
       
       set({ 


### PR DESCRIPTION
# [feat] 게시글 조회 API 연동

## 😺 Issue
- #30 

## ✅ 작업 리스트
- 게시글 목록 페이지
    - 게시글 목록 API 연동
- 게시글 상세 페이지 
    - 게시글 상세 API 연동
- 상태 관리
    - useConcernStore 수정
    -  useBoardDetailStore 수정
    - 페이지네이션 데이터 처리

## ⚙️ 작업 내용
- Page 객체 형태로 오는 API 응답을 처리하여 게시글 목록을 표시하고, 각 게시글 카드를 클릭하면 상세 페이지로 이동하도록 구현 
- 게시글 목록과 상세 정보의 상태관리 추가
- 로딩 상태와 에러 처리 구현

## 📷 테스트 / 구현 내용
![image](https://github.com/user-attachments/assets/fb48ea49-46eb-4af0-92c2-116a849804ba)
![image](https://github.com/user-attachments/assets/8f8e5231-84b4-45fc-a27c-cf5fc3fd5f2b)
