### PR TITLE
[feat] 고민 상세 게시판 댓글 및 AI 답변 API 연동

### DIFF
--- a/src/components/CommentInput.tsx
+++ b/src/components/CommentInput.tsx
@@ -1,11 +1,15 @@
 import React from 'react'
+import axios from 'axios'
 import { useCommentStore } from '../stores/useCommentStore'
+import { useParams } from 'react-router-dom'
 
 interface CommentInputProps {
   parentId?: number | null
 }
 
 export const CommentInput: React.FC<CommentInputProps> = ({ parentId = null }) => {
+  const { pageNumber } = useParams<{ pageNumber: string }>() // 추후 App.ts에서 boardId로 수정
+  const boardId = pageNumber
   const {
     commentContent,
     setCommentContent,
@@ -22,8 +26,38 @@ export const CommentInput: React.FC<CommentInputProps> = ({ parentId = null }) =
       : setCommentContent(val)
   }
 
-  const handleSubmit = () => {
-    
+  const handleSubmit = async () => {
+    const token = localStorage.getItem('accessToken')
+    if (!token) return
+
+    const content = value.trim()
+    if (!content) return
+
+    try {
+      const response = await axios.post(`http://moonrabbit-api.kro.kr/api/answer/save?boardId=${boardId}`,
+        {
+          content,
+          parentId: parentId ?? null,
+        },
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      )
+
+      const newComment = response.data
+      useCommentStore.getState().addComment(newComment, parentId)
+      console.log(newComment)
+
+      // 입력창 초기화
+      parentId !== null
+        ? setReplyContent(parentId, '')
+        : setCommentContent('')
+    } catch (err) {
+      console.error('댓글 등록 실패', err)
+    }
   }
 
   return (
@@ -35,7 +69,7 @@ export const CommentInput: React.FC<CommentInputProps> = ({ parentId = null }) =
         onChange={onChange}
       />
       <div 
-        className='flex justify-self-end bg-mainColor text-mainWhite w-fit p-[4px] px-[10px] rounded-[10px] text-[16px] mt-[12px] shadow-[0_2px_4px_rgba(0,0,0,0.25)]'
+        className='cursor-pointer flex justify-self-end bg-mainColor text-mainWhite w-fit p-[4px] px-[10px] rounded-[10px] text-[16px] mt-[12px] shadow-[0_2px_4px_rgba(0,0,0,0.25)]'
         onClick={handleSubmit}
       >
         등록

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -11,7 +11,7 @@ interface CommentItemProps {
 }
 
 export const CommentItem: React.FC<CommentItemProps> = ({ comment, depth = 0 }) => {
-  const { toggleCommentLike, replyTargetId, setReplyTargetId } = useCommentStore()
+  const { toggleCommentLike, replyTargetId, setReplyTargetId, deleteComment, currentUser } = useCommentStore()
   const showReplyInput = replyTargetId === comment.id
 
   return (
@@ -22,7 +22,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({ comment, depth = 0 }) 
       </div>
       <p className="whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight my-4">{comment.content}</p>
       <div className="flex text-[16px]">
-        <p className='mr-4'>{comment.date}</p>
+        <p className='mr-4'>{comment.createdAt.split('T')[0].replace(/-/g, '.')}</p>
         {depth === 0 && 
           <div
             className='mr-4 cursor-pointer'
@@ -33,6 +33,14 @@ export const CommentItem: React.FC<CommentItemProps> = ({ comment, depth = 0 }) 
             {replyTargetId === comment.id ? '닫기' : '답글쓰기'}
           </div>
         }
+        {currentUser === comment.author && (
+          <div
+            className='mr-4 text-mainColor cursor-pointer'
+            onClick={() => deleteComment(comment.id)}
+          >
+            삭제
+          </div>
+        )}
         <div onClick={() => toggleCommentLike(comment.id)}>
           <img src={comment.like ? Liked : Like} alt="좋아요아이콘" className='cursor-pointer' />
         </div>
@@ -44,10 +52,10 @@ export const CommentItem: React.FC<CommentItemProps> = ({ comment, depth = 0 }) 
         </div>
       }
       {/* 답글 렌더링 */}
-      {comment.replies.length > 0 && (
+      {comment.replies?.length > 0 && (
         <div className='ml-12 mt-2'>
           {comment.replies.map(reply => (
-            <CommentItem key={reply.id} comment={reply}  depth={depth + 1} />
+            <CommentItem key={reply.id} comment={reply} depth={depth + 1} />
           ))}
         </div>
       )}

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -33,7 +33,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({ comment, depth = 0 }) 
             {replyTargetId === comment.id ? '닫기' : '답글쓰기'}
           </div>
         }
-        {currentUser === comment.author && (
+        {currentUser !== comment.author && (
           <div
             className='mr-4 text-mainColor cursor-pointer'
             onClick={() => deleteComment(comment.id)}

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -17,8 +17,8 @@ export const CommentItem: React.FC<CommentItemProps> = ({ comment, depth = 0 }) 
   return (
     <div className="mt-12">
       <div className="flex items-center">
-        <img src={comment.profileImage} className="w-[50px] h-[50px] rounded-[50%] mr-[8px]" />
-        <p className="text-[18px]">{comment.author}</p>
+        <img src={comment.profileImg} className="w-[50px] h-[50px] rounded-[50%] mr-[8px]" />
+        <p className="text-[18px]">{comment.nickname}</p>
       </div>
       <p className="whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight my-4">{comment.content}</p>
       <div className="flex text-[16px]">
@@ -33,7 +33,7 @@ export const CommentItem: React.FC<CommentItemProps> = ({ comment, depth = 0 }) 
             {replyTargetId === comment.id ? '닫기' : '답글쓰기'}
           </div>
         }
-        {currentUser !== comment.author && (
+        {currentUser !== comment.nickname && (
           <div
             className='mr-4 text-mainColor cursor-pointer'
             onClick={() => deleteComment(comment.id)}

--- a/src/components/CommentItem.tsx
+++ b/src/components/CommentItem.tsx
@@ -13,7 +13,7 @@ interface CommentItemProps {
 export const CommentItem: React.FC<CommentItemProps> = ({ comment, depth = 0 }) => {
   const { toggleCommentLike, replyTargetId, setReplyTargetId, deleteComment, currentUser } = useCommentStore()
   const showReplyInput = replyTargetId === comment.id
-
+  
   return (
     <div className="mt-12">
       <div className="flex items-center">
@@ -33,17 +33,18 @@ export const CommentItem: React.FC<CommentItemProps> = ({ comment, depth = 0 }) 
             {replyTargetId === comment.id ? '닫기' : '답글쓰기'}
           </div>
         }
-        {currentUser !== comment.nickname && (
+        {currentUser !== comment.userId && (
           <div
             className='mr-4 text-mainColor cursor-pointer'
             onClick={() => deleteComment(comment.id)}
           >
-            삭제
+            삭제하기
           </div>
         )}
-        <div onClick={() => toggleCommentLike(comment.id)}>
+        <div onClick={() => toggleCommentLike(comment.id)} className='mr-2'>
           <img src={comment.like ? Liked : Like} alt="좋아요아이콘" className='cursor-pointer' />
         </div>
+        <div>{comment.likeCount}</div>
       </div>
       {/* 답글Input */}
       {showReplyInput && 

--- a/src/components/ConcernComment.tsx
+++ b/src/components/ConcernComment.tsx
@@ -9,7 +9,7 @@ import Comment from "../assets/images/Comment.svg";
 export const ConcernComment: React.FC = () => {
   const { pageNumber } = useParams<{ pageNumber: string }>()
   const boardId = pageNumber
-  const { comments, setComments } = useCommentStore()
+  const { comments, setComments, latestCommentId } = useCommentStore()
 
   useEffect(() => {
     const getComments = async () => {

--- a/src/components/ConcernComment.tsx
+++ b/src/components/ConcernComment.tsx
@@ -11,40 +11,12 @@ export const ConcernComment: React.FC = () => {
   const boardId = pageNumber
   const { comments, setComments } = useCommentStore()
 
-  // 유저 정보  get
-  const getUserInfo = async (userId: number) => {
-    try {
-      const response = await axios.get(`http://moonrabbit-api.kro.kr/api/users/${userId}`)
-      const authorData = await response.data
-      return {
-        nickname: authorData.nickname,
-        profileImage: authorData.profileImageUrl,
-      }
-    } catch (err) {
-      console.error('댓글 작성자 조회 실패:', err)
-    }
-  }
-
   useEffect(() => {
     const getComments = async () => {
       try {
-        const response = await axios.get(`http://moonrabbit-api.kro.kr/api/boards/list/${boardId}`)
-        const data = await response.data
-        const answers = await Promise.all(
-        data.answers.map(async (ans: any, index: number) => {
-          //const author = await getUserInfo(ans.userId)
-          return {
-            id: index + 1,
-            author: '임시닉넴',
-            profileImage: '',
-            content: ans.content,
-            createdAt: ans.createdAt,
-            like: false, 
-            replies: [], 
-          }
-        })
-      )
-
+        const response = await axios.get(`http://moonrabbit-api.kro.kr/api/answer/board/${boardId}`)
+        const answers = await response.data
+        console.log(answers)
       setComments(answers)
       } catch (error) {
         console.error('댓글 조회 실패', error)

--- a/src/components/ConcernComment.tsx
+++ b/src/components/ConcernComment.tsx
@@ -38,8 +38,8 @@ export const ConcernComment: React.FC = () => {
   //           profileImage: author.profileImage,
   //           content: ans.content,
   //           date: ans.createdAt.split('T')[0].replace(/-/g, '.'),
-  //           like: false, // 따로 작업
-  //           replies: [], // 얘는 어케하지
+  //           like: false, 
+  //           replies: [], 
   //         }
   //       })
   //     )

--- a/src/components/ConcernComment.tsx
+++ b/src/components/ConcernComment.tsx
@@ -1,13 +1,62 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import axios from 'axios'
 import { useCommentStore } from '../stores/useCommentStore'
 import { CommentInput } from './CommentInput'
 import { CommentItem } from './CommentItem'
 import Comment from "../assets/images/Comment.svg";
 
 export const ConcernComment: React.FC = () => {
-  const { comments } = useCommentStore()
-  const getTotalCommentCount = (list: typeof comments): number =>
-    list.reduce((acc, c) => acc + 1 + getTotalCommentCount(c.replies), 0)
+  const { boardId } = useParams<{ boardId: string }>()
+  const { comments, setComments } = useCommentStore()
+
+  // 유저 정보  get
+  const getUserInfo = async (userId: number) => {
+    try {
+      const response = await axios.get(`http://moonrabbit-api.kro.kr/api/users/${userId}`)
+      const authorData = await response.data
+      return {
+        nickname: authorData.nickname,
+        profileImage: authorData.profileImageUrl,
+      }
+    } catch (err) {
+      console.error('댓글 작성자 조회 실패:', err)
+    }
+  }
+
+  // useEffect(() => {
+  //   const getComments = async () => {
+  //     try {
+  //       const response = await axios.get(`http://moonrabbit-api.kro.kr/api/boards/list/${boardId}`)
+  //       const data = await response.data
+  //       const answers = await Promise.all(
+  //       data.answers.map(async (ans: any, index: number) => {
+  //         const author = await getUserInfo(ans.userId)
+  //         return {
+  //           id: index + 1,
+  //           author: author.nickname,
+  //           profileImage: author.profileImage,
+  //           content: ans.content,
+  //           date: ans.createdAt.split('T')[0].replace(/-/g, '.'),
+  //           like: false, // 따로 작업
+  //           replies: [], // 얘는 어케하지
+  //         }
+  //       })
+  //     )
+
+  //     setComments(answers)
+  //     } catch (error) {
+  //       console.error('댓글 조회 실패', error)
+  //     }
+  //   }
+  //   getComments()
+  // }, [])
+
+  const getTotalCommentCount = (list: Comment[] = []): number =>
+    list.reduce(
+    (acc, c) => acc + 1 + getTotalCommentCount(c.replies ?? []),
+    0
+  )
   const totalCommentCount = getTotalCommentCount(comments)
 
   return (

--- a/src/components/ConcernComment.tsx
+++ b/src/components/ConcernComment.tsx
@@ -7,7 +7,8 @@ import { CommentItem } from './CommentItem'
 import Comment from "../assets/images/Comment.svg";
 
 export const ConcernComment: React.FC = () => {
-  const { boardId } = useParams<{ boardId: string }>()
+  const { pageNumber } = useParams<{ pageNumber: string }>()
+  const boardId = pageNumber
   const { comments, setComments } = useCommentStore()
 
   // 유저 정보  get
@@ -24,33 +25,33 @@ export const ConcernComment: React.FC = () => {
     }
   }
 
-  // useEffect(() => {
-  //   const getComments = async () => {
-  //     try {
-  //       const response = await axios.get(`http://moonrabbit-api.kro.kr/api/boards/list/${boardId}`)
-  //       const data = await response.data
-  //       const answers = await Promise.all(
-  //       data.answers.map(async (ans: any, index: number) => {
-  //         const author = await getUserInfo(ans.userId)
-  //         return {
-  //           id: index + 1,
-  //           author: author.nickname,
-  //           profileImage: author.profileImage,
-  //           content: ans.content,
-  //           date: ans.createdAt.split('T')[0].replace(/-/g, '.'),
-  //           like: false, 
-  //           replies: [], 
-  //         }
-  //       })
-  //     )
+  useEffect(() => {
+    const getComments = async () => {
+      try {
+        const response = await axios.get(`http://moonrabbit-api.kro.kr/api/boards/list/${boardId}`)
+        const data = await response.data
+        const answers = await Promise.all(
+        data.answers.map(async (ans: any, index: number) => {
+          const author = await getUserInfo(ans.userId)
+          return {
+            id: index + 1,
+            author: '임시닉넴',
+            profileImage: '',
+            content: ans.content,
+            createdAt: ans.createdAt,
+            like: false, 
+            replies: [], 
+          }
+        })
+      )
 
-  //     setComments(answers)
-  //     } catch (error) {
-  //       console.error('댓글 조회 실패', error)
-  //     }
-  //   }
-  //   getComments()
-  // }, [])
+      setComments(answers)
+      } catch (error) {
+        console.error('댓글 조회 실패', error)
+      }
+    }
+    getComments()
+  }, [])
 
   const getTotalCommentCount = (list: Comment[] = []): number =>
     list.reduce(

--- a/src/components/ConcernComment.tsx
+++ b/src/components/ConcernComment.tsx
@@ -9,7 +9,7 @@ import Comment from "../assets/images/Comment.svg";
 export const ConcernComment: React.FC = () => {
   const { pageNumber } = useParams<{ pageNumber: string }>()
   const boardId = pageNumber
-  const { comments, setComments, latestCommentId } = useCommentStore()
+  const { comments, setComments } = useCommentStore()
 
   useEffect(() => {
     const getComments = async () => {

--- a/src/components/ConcernComment.tsx
+++ b/src/components/ConcernComment.tsx
@@ -32,7 +32,7 @@ export const ConcernComment: React.FC = () => {
         const data = await response.data
         const answers = await Promise.all(
         data.answers.map(async (ans: any, index: number) => {
-          const author = await getUserInfo(ans.userId)
+          //const author = await getUserInfo(ans.userId)
           return {
             id: index + 1,
             author: '임시닉넴',

--- a/src/components/ConcernPost.tsx
+++ b/src/components/ConcernPost.tsx
@@ -81,26 +81,11 @@ export const ConcernContent: React.FC<ConcernContentProps> = ({
   )
 }
 
-interface Answer {
-  userId: number;
-  boardId: number;
-  content: string;
-  createdAt: string;
-}
-
-interface ConcernAnswerProps {
-  answers: Answer[];
-}
-
-export const ConcernAnswer: React.FC<ConcernAnswerProps> = ({ answers }) => {
+export const ConcernAnswer: React.FC = () => {
   return(
     <div className='text-darkWalnut font-mainFont bg-mainWhite h-auto w-4/5 rounded-[40px] p-[50px] shadow-[0_2px_4px_rgba(0,0,0,0.25)]'>
       <p className='text-[30px] mb-[20px]'>달토끼 답변</p>
-      {answers.length > 0 ? (
-        <p className='whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight'>{answers[0].content}</p>
-      ) : (
-        <p className='whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight'>아직 답변이 없어요. 첫 답변을 남겨보세요!</p>
-      )}
+      <p className='whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight'>🐰･･･달토끼가 답변을 작성 중이에요. 조금만 기다려주세요･･･✏️</p>
     </div>
   )
 }

--- a/src/components/ConcernPost.tsx
+++ b/src/components/ConcernPost.tsx
@@ -26,6 +26,7 @@ export const ConcernContent: React.FC<ConcernContentProps> = ({
 }) => {
   const { concern, toggleConcernLike } = useConcernDetailStore()
   const { comments } = useCommentStore()
+  const { setAiAnswer } = useConcernStore()
   const getTotalCommentCount = (list: Comment[] = []): number =>
     list.reduce(
     (acc, c) => acc + 1 + getTotalCommentCount(c.replies ?? []),
@@ -35,6 +36,7 @@ export const ConcernContent: React.FC<ConcernContentProps> = ({
 
   const navigate = useNavigate()
   const { pageNumber } = useParams()
+  const boardId = pageNumber
   const currentId = Number(pageNumber)
   const { concerns } = useConcernStore()
   const currentIndex = concerns.findIndex(c => c.id === currentId)
@@ -50,6 +52,18 @@ export const ConcernContent: React.FC<ConcernContentProps> = ({
       navigate(`/night-sky/${nextId}`)
     }
   }
+
+  useEffect(() => {
+    const getAiAnswer  = async () => {
+      try {
+        const response = await axios.get(`http://moonrabbit-api.kro.kr/api/board/${boardId}/assistant`)
+        setAiAnswer(response.data.reply)
+      } catch (error) {
+        console.error('AI 답변변 조회 실패', error)
+      }
+    }
+    getAiAnswer()
+  }, [])
 
   
   return (

--- a/src/components/ConcernPost.tsx
+++ b/src/components/ConcernPost.tsx
@@ -7,7 +7,6 @@ import Like from "../assets/images/Like.svg";
 import Liked from "../assets/images/Liked.svg";
 import PrevArrow from "../assets/images/PrevArrow.svg"
 import NextArrow from "../assets/images/NextArrow.svg"
-import { useParams } from 'react-router-dom';
 
 interface ConcernContentProps {
   title: string;
@@ -24,8 +23,11 @@ export const ConcernContent: React.FC<ConcernContentProps> = ({
 }) => {
   const { concern, toggleConcernLike } = useConcernDetailStore()
   const { comments } = useCommentStore()
-  const getTotalCommentCount = (list: typeof comments): number =>
-    list.reduce((acc, c) => acc + 1 + getTotalCommentCount(c.replies), 0)
+  const getTotalCommentCount = (list: Comment[] = []): number =>
+    list.reduce(
+    (acc, c) => acc + 1 + getTotalCommentCount(c.replies ?? []),
+    0
+  )
   const totalCommentCount = getTotalCommentCount(comments)
   
   return (

--- a/src/components/ConcernPost.tsx
+++ b/src/components/ConcernPost.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { useConcernDetailStore } from '../stores/useConcernDetailStore';
 import { useCommentStore } from '../stores/useCommentStore';
+import { useConcernStore } from '../stores/useConcernStore';
+import { useNavigate, useParams } from 'react-router-dom';
 import Comment from "../assets/images/Comment.svg";
 import Report from '../assets/images/Report.svg';
 import Like from "../assets/images/Like.svg";
@@ -29,10 +31,32 @@ export const ConcernContent: React.FC<ConcernContentProps> = ({
     0
   )
   const totalCommentCount = getTotalCommentCount(comments)
+
+  const navigate = useNavigate()
+  const { pageNumber } = useParams()
+  const currentId = Number(pageNumber)
+
+  const { concerns } = useConcernStore()
+  const currentIndex = concerns.findIndex(c => c.id === currentId)
+
+  const goToPrev = () => {
+    if (currentIndex > 0) {
+      const prevId = concerns[currentIndex - 1].id
+      navigate(`/night-sky/${prevId}`)
+    }
+  }
+
+  const goToNext = () => {
+    if (currentIndex < concerns.length - 1) {
+      const nextId = concerns[currentIndex + 1].id
+      navigate(`/night-sky/${nextId}`)
+    }
+  }
+
   
   return (
     <div className='flex items-center justify-center w-full'>
-      <img src={PrevArrow} alt='이전 고민' />
+      <img src={PrevArrow} alt='이전 고민' onClick={goToPrev} className='cursor-pointer' />
       <div className='text-darkWalnut font-mainFont mx-2 bg-mainWhite h-auto w-4/5 rounded-[40px] p-[50px] pb-[32px] my-24 shadow-[0_2px_4px_rgba(0,0,0,0.25)]'>
         <p className='text-[30px]'>{title}</p>
         <div className='flex items-center my-[20px]'>
@@ -52,7 +76,7 @@ export const ConcernContent: React.FC<ConcernContentProps> = ({
           <p>{date}</p>
         </div>
       </div>
-      <img src={NextArrow} alt='다음 고민' />
+      <img src={NextArrow} alt='다음 고민' onClick={goToNext} className='cursor-pointer' />
     </div>
   )
 }

--- a/src/components/ConcernPost.tsx
+++ b/src/components/ConcernPost.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect} from 'react';
 import { useConcernDetailStore } from '../stores/useConcernDetailStore';
 import { useCommentStore } from '../stores/useCommentStore';
 import { useConcernStore } from '../stores/useConcernStore';
 import { useNavigate, useParams } from 'react-router-dom';
+import axios from 'axios';
 import Comment from "../assets/images/Comment.svg";
 import Report from '../assets/images/Report.svg';
 import Like from "../assets/images/Like.svg";
@@ -35,17 +36,14 @@ export const ConcernContent: React.FC<ConcernContentProps> = ({
   const navigate = useNavigate()
   const { pageNumber } = useParams()
   const currentId = Number(pageNumber)
-
   const { concerns } = useConcernStore()
   const currentIndex = concerns.findIndex(c => c.id === currentId)
-
   const goToPrev = () => {
     if (currentIndex > 0) {
       const prevId = concerns[currentIndex - 1].id
       navigate(`/night-sky/${prevId}`)
     }
   }
-
   const goToNext = () => {
     if (currentIndex < concerns.length - 1) {
       const nextId = concerns[currentIndex + 1].id
@@ -82,10 +80,11 @@ export const ConcernContent: React.FC<ConcernContentProps> = ({
 }
 
 export const ConcernAnswer: React.FC = () => {
+  const { aiAnswer } = useConcernStore()
   return(
     <div className='text-darkWalnut font-mainFont bg-mainWhite h-auto w-4/5 rounded-[40px] p-[50px] shadow-[0_2px_4px_rgba(0,0,0,0.25)]'>
       <p className='text-[30px] mb-[20px]'>달토끼 답변</p>
-      <p className='whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight'>🐰･･･달토끼가 답변을 작성 중이에요. 조금만 기다려주세요･･･✏️</p>
+      <p className='whitespace-pre-line break-words font-gothicFont text-[18px] leading-tight'>{aiAnswer}</p>
     </div>
   )
 }

--- a/src/components/CreateConcernModal.tsx
+++ b/src/components/CreateConcernModal.tsx
@@ -4,7 +4,6 @@ import axios from 'axios';
 import CategoryBar from './CategoryBar';
 import { useResponsiveStore } from '../stores/useResponsiveStore';
 import { useAnonymousStore } from '../stores/useAnonymousStore';
-import { useConcernStore } from '../stores/useConcernStore';
 
 const MODAL_STYLES = {
   width: 'w-[1200px]',
@@ -26,12 +25,12 @@ interface CreateConcernModalProps {
 }
 
 const categoryMap: Record<string, string> = {
-  '가족': 'family',
-  '연애': 'love',
-  '진로': 'career',
-  '정신건강': 'mental',
-  '사회생활': 'society',
-  '대인관계': 'personal',
+  '가족': 'FAMILY',
+  '연애': 'LOVE',
+  '진로': 'CAREER',
+  '정신건강': 'MENTAL',
+  '사회생활': 'SOCIETY',
+  '대인관계': 'PERSONAL',
 }
 
 const CreateConcernModal: React.FC<CreateConcernModalProps> = ({
@@ -50,7 +49,6 @@ const CreateConcernModal: React.FC<CreateConcernModalProps> = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate()
-  const { setAiAnswer } = useConcernStore();
 
   if (!isOpen) return null;
 
@@ -72,14 +70,6 @@ const CreateConcernModal: React.FC<CreateConcernModalProps> = ({
 
   try {
     const token = localStorage.getItem('accessToken'); // 또는 sessionStorage.getItem('accessToken');
-    const category = categoryMap[selectedCategory]
-    const assistantRes = await axios.post(
-      `http://moonrabbit-api.kro.kr/assistant/${category}`,
-      {
-        content
-      }
-    )
-    setAiAnswer(assistantRes.data)
 
     const response = await axios.post(
       `http://moonrabbit-api.kro.kr/api/boards/save`,
@@ -98,8 +88,18 @@ const CreateConcernModal: React.FC<CreateConcernModalProps> = ({
       }
     );
 
+    const category = categoryMap[selectedCategory]
+    const boardId = response.data.boardId
+    const assistantRes = await axios.post(
+      `http://moonrabbit-api.kro.kr/api/board/${boardId}/assistant/${category}`,
+      {
+        message: content
+      }
+    )
+
+    console.log('AI답변:', assistantRes.data)
     console.log('게시글 생성 성공:', response.data);
-    onCreateConcern();
+    onCreateConcern(); 
     handleClose();
     navigate('/night-sky/'+response.data.boardId)
   } catch (err) {

--- a/src/pages/NightSkyDetailPage.tsx
+++ b/src/pages/NightSkyDetailPage.tsx
@@ -39,7 +39,7 @@ const NightSkyDetailPage: React.FC = () => {
   }
   
   return (
-    <div className="flex flex-col items-center justify-center w-full max-w-4xl mx-auto px-4 py-8">
+    <div className="flex flex-col items-center justify-center w-full">
       <ConcernContent 
         title={boardDetail.title}
         content={boardDetail.content}

--- a/src/stores/useCommentStore.ts
+++ b/src/stores/useCommentStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import axios from 'axios';
 
 export interface Comment {
   id: number;
@@ -111,9 +112,8 @@ export const useCommentStore = create<CommentStore>((set, get) => ({
     if (!token) return
 
     try {
-      await fetch(`http://moonrabbit-api.kro.kr/api/answer/delete/${commentId}`, {
-        method: 'DELETE',
-        headers: {
+      await axios.delete(`http://moonrabbit-api.kro.kr/api/answer/delete/${commentId}`, {
+          headers: {
           'Authorization': `Bearer ${token}`,
         },
       })

--- a/src/stores/useCommentStore.ts
+++ b/src/stores/useCommentStore.ts
@@ -3,10 +3,14 @@ import axios from 'axios';
 
 export interface Comment {
   id: number;
-  profileImage: string;
-  author: string;
+  profileImg: string;
+  nickname: string;
+  userId: number;
+  parentId: number;
   content: string;
   createdAt: string;
+  likeCount: number;
+  reportCount: number;
   like: boolean;
   replies: Comment[];
 }

--- a/src/stores/useCommentStore.ts
+++ b/src/stores/useCommentStore.ts
@@ -5,13 +5,15 @@ export interface Comment {
   profileImage: string;
   author: string;
   content: string;
-  date: string;
+  createdAt: string;
   like: boolean;
   replies: Comment[];
 }
 
 interface CommentStore {
   comments: Comment[]
+  setComments: (comments: Comment[]) => void
+  addComment: (newComment: Comment, parentId?: number | null) => void
   replyTargetId: number | null
   inputValues: Record<string | number, string>
   setReplyTargetId: (id: number | null) => void
@@ -21,6 +23,9 @@ interface CommentStore {
   replyContents: { [id: number]: string }
   setReplyContent: (id: number, content: string) => void
   toggleCommentLike: (id: number) => void
+  currentUser: string;
+  setCurrentUser: (user: string) => void;
+  deleteComment: (commentId: number) => void;
 }
 
 function toggleLikeRecursive(comments: Comment[], id: number): Comment[] {
@@ -33,48 +38,45 @@ function toggleLikeRecursive(comments: Comment[], id: number): Comment[] {
   })
 }
 
-const initialComments: Comment[] = [
-  {
-    id: 1,
-    author: '익명1',
-    profileImage: 'https://i.pravatar.cc/150?img=1',
-    content: '저도 작년에 그랬는데 결국 좋은 결과 있었어요!',
-    date: '2025.06.03',
-    like: true,
-    replies: [
-      {
-        id: 4,
-        author: '익명4',
-        profileImage: 'https://i.pravatar.cc/150?img=1',
-        content: '우와 용기 얻고 갑니다.',
-        date: '2025.06.03',
-        like: false,
-        replies: [],
-      },
-      {
-        id: 5,
-        author: '익명5',
-        profileImage: 'https://i.pravatar.cc/150?img=1',
-        content: '우와 용기 얻고 갑니다.',
-        date: '2025.06.03',
-        like: false,
-        replies: [],
-      },
-    ],
-  },
-  {
-    id: 2,
-    author: '익명2',
-    profileImage: 'https://i.pravatar.cc/150?img=1',
-    content: '너무 자책하지 마세요. 누구나 실수할 수 있어요.',
-    date: '2025.06.04',
-    like: false,
-    replies: [],
-  },
-]
+function insertReplyRecursive(comments: Comment[], parentId: number, reply: Comment): Comment[] {
+  return comments.map(comment => {
+    if (comment.id === parentId) {
+      return {
+        ...comment,
+        replies: [reply, ...comment.replies]
+      }
+    }
+    return {
+      ...comment,
+      replies: insertReplyRecursive(comment.replies, parentId, reply)
+    }
+  })
+}
+
+function removeCommentRecursive(comments: Comment[], id: number): Comment[] {
+  return comments
+    .filter(comment => comment.id !== id)
+    .map(comment => ({
+      ...comment,
+      replies: removeCommentRecursive(comment.replies, id)
+    }))
+}
 
 export const useCommentStore = create<CommentStore>((set, get) => ({
-  comments: initialComments,
+  comments: [],
+  setComments: (comments) => set({ comments }),
+
+  addComment: (newComment, parentId = null) => {
+    const updated = [...get().comments]
+
+    if (parentId === null) {
+      set({ comments: [newComment, ...updated] })
+    } else {
+      const updatedComments = insertReplyRecursive(updated, parentId, newComment)
+      set({ comments: updatedComments })
+    }
+  },
+
   replyTargetId: null,
   inputValues: {},
 
@@ -101,4 +103,24 @@ export const useCommentStore = create<CommentStore>((set, get) => ({
     set((state) => ({
       comments: toggleLikeRecursive(state.comments, id),
   })),
+  currentUser: '',
+  setCurrentUser: (user) => set({ currentUser: user }),
+
+  deleteComment: async (commentId: number) => {
+    const token = localStorage.getItem('accessToken')
+    if (!token) return
+
+    try {
+      await fetch(`http://moonrabbit-api.kro.kr/api/answer/delete/${commentId}`, {
+        method: 'DELETE',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+        },
+      })
+      const updatedComments = removeCommentRecursive(get().comments, commentId)
+      set({ comments: updatedComments })
+    } catch (err) {
+      console.error('댓글 삭제 실패', err)
+    }
+  }
 }))

--- a/src/stores/useConcernStore.ts
+++ b/src/stores/useConcernStore.ts
@@ -42,6 +42,9 @@ interface ConcernStore {
   newConcernTitle: string;
   newConcernContent: string;
   newConcernCategory: string;
+
+  //AI 답변
+  aiAnswer: string;
   
   // 상태 
   setSelectedCategory: (category: string) => void;
@@ -51,6 +54,7 @@ interface ConcernStore {
   setNewConcernCategory: (category: string) => void;
   resetForm: () => void;
   fetchConcerns: () => Promise<void>;
+  setAiAnswer: (aiAns: string) => void;
 }
 
 const transformBoardToConcern = (board: Board): Concern => {
@@ -82,6 +86,7 @@ export const useConcernStore = create<ConcernStore>((set, get) => ({
   newConcernTitle: '',
   newConcernContent: '',
   newConcernCategory: '학교',
+  aiAnswer: '',
   
   setSelectedCategory: (category) => {
     const { concerns } = get();
@@ -119,5 +124,6 @@ export const useConcernStore = create<ConcernStore>((set, get) => ({
     } catch (error) {
       console.error('Failed to fetch concerns:', error);
     }
-  }
+  },
+  setAiAnswer: (aiAns) => set({ aiAnswer: aiAns }),
 })) 


### PR DESCRIPTION
# [feat] 고민 상세 게시판 댓글 및 AI 답변 API 연동

## 😺 Issue
- #31 

## ✅ 작업 리스트
- 댓글 API 연동
- AI 답변 API 연동
- 고민 상세페이지 화살표로 페이지 이동 추가

## ⚙️ 작업 내용
- 댓글 API 연동
  - 삭제 버튼 UI 추가 (댓글작성자에 관계없이 버튼 노출되어잇음)
  - 조회, 생성, 삭제 API 연동
- AI 답변 API 연동
- 고민 상세페이지 화살표로 페이지 이동 추가
  - onClick함수 추가
  - 게시글 목록 가져와서 다음 인덱스 찾아서 이동

## 📷 테스트 / 구현 내용
- ![image](https://github.com/user-attachments/assets/82d719b3-4dea-4ead-a88c-c9556fdc744e)

## 🤔 문제점 / 궁금한 점 (필요 시)
- AI 답변 생성까진 됐으나 ConcernPost.tsx에서 불러오기 기능 연동 못함