### PR TITLE
[feat] 소셜로그인 API 연동 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import LoginSignupPage from './pages/LoginSignupPage'
 import NightSkyPage from './pages/NightSkyPage'
 import NightSkyDetailPage from './pages/NightSkyDetailPage'
 import Footer from './components/Footer'
+import LoginLoadingPage from './pages/LoginLoadingPage'
 
 function App() {
   const res = useResponsiveStore((state) => state.res)
@@ -28,6 +29,7 @@ function App() {
         <Routes>
           <Route path="/" element={<MainPage />} />
           <Route path='/login' element={<LoginSignupPage />} />
+          <Route path='/loading' element={<LoginLoadingPage />} />
           <Route path='/night-sky' element={<NightSkyPage />} />
           <Route path='/night-sky/:pageNumber' element={<NightSkyDetailPage />} />
         </Routes>

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -47,10 +47,9 @@ export const LoginForm = () => {
     }
   }
 
-  const handleSNSLogin = (isGoogle: boolean) => async () => {
+  const handleSNSLogin = (platform: string) => async () => {
     try {
-      const provider = isGoogle ? 'google' : 'kakao';
-      window.location.href = `http://moonrabbit-api.kro.kr/oauth2/authorization/${provider}`
+      window.location.href = `http://moonrabbit-api.kro.kr/api/users/${platform}`
       navigate('/')
     } catch (error) {
       console.error('소셜 로그인 오류:', error)
@@ -79,8 +78,8 @@ export const LoginForm = () => {
         로그인 (Login)
       </LoginButton>
       <div className={clsx('flex gap-2', isMobile ? 'flex-col' : 'lg:gap-4 px-0 flex-col lg:flex-row lg:px-4')}>
-        <SocialLogin onClick={handleSNSLogin(true)} SNSLoginImg={GoogleLoginImg} />
-        <SocialLogin onClick={handleSNSLogin(false)} SNSLoginImg={kakaoLoginImg} />
+        <SocialLogin onClick={handleSNSLogin('google')} SNSLoginImg={GoogleLoginImg} />
+        <SocialLogin onClick={handleSNSLogin('kakao')} SNSLoginImg={kakaoLoginImg} />
       </div>
     </div>
   )

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -47,6 +47,17 @@ export const LoginForm = () => {
     }
   }
 
+  const handleSNSLogin = (isGoogle: boolean) => async () => {
+    try {
+      const provider = isGoogle ? 'google' : 'kakao';
+      window.location.href = `http://moonrabbit-api.kro.kr/oauth2/authorization/${provider}`
+      navigate('/')
+    } catch (error) {
+      console.error('소셜 로그인 오류:', error)
+      alert('소셜 로그인에 실패했습니다.')
+    }
+  }
+
   return (
     <div className={clsx('flex flex-col justify-center p-15 bg-white', isMobile ? 'w-full' : 'w-4/7')}>
       <LoginFormHeader />
@@ -68,8 +79,8 @@ export const LoginForm = () => {
         로그인 (Login)
       </LoginButton>
       <div className={clsx('flex gap-2', isMobile ? 'flex-col' : 'lg:gap-4 px-0 flex-col lg:flex-row lg:px-4')}>
-        <SocialLogin SNSLoginImg={GoogleLoginImg} />
-        <SocialLogin SNSLoginImg={kakaoLoginImg} />
+        <SocialLogin onClick={handleSNSLogin(true)} SNSLoginImg={GoogleLoginImg} />
+        <SocialLogin onClick={handleSNSLogin(false)} SNSLoginImg={kakaoLoginImg} />
       </div>
     </div>
   )
@@ -110,7 +121,6 @@ export const SignupForm = () => {
       return
     }
 
-    // API 요청
     try {
       const response = await axios.post('http://moonrabbit-api.kro.kr/api/users/register', {
         email,
@@ -219,7 +229,11 @@ export const LoginButton = ({ children, onClick, className }: LoginButtonProps) 
   </button>
 )
 
-export const SocialLogin = ({ SNSLoginImg }) => {
+interface SocialLoginProps {
+  SNSLoginImg: string;
+  onClick: () => void;
+}
+export const SocialLogin = ({ SNSLoginImg, onClick }: SocialLoginProps) => {
   const isGoogle = SNSLoginImg === GoogleLoginImg
   const res = useResponsiveStore((state) => state.res)
   const isMobile = res === 'mo'
@@ -230,7 +244,8 @@ export const SocialLogin = ({ SNSLoginImg }) => {
       isGoogle ? 
       (isMobile ? 'p-[2px] bg-[#F2F2F2] h-[50px]' : 'flex-1 bg-[#F2F2F2] p-1 min-h-[50px] max-h-[50px]') : 
       (isMobile ? 'bg-[#FEE500] h-[50px]' : 'flex-1 bg-[#FEE500] max-h-[50px]')
-      )}>
+      )}
+    onClick={onClick}>
     <img src={SNSLoginImg} className='h-full object-contain'/>
   </div>
   )

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -50,7 +50,6 @@ export const LoginForm = () => {
   const handleSNSLogin = (platform: string) => async () => {
     try {
       window.location.href = `http://moonrabbit-api.kro.kr/api/users/${platform}`
-      navigate('/')
     } catch (error) {
       console.error('소셜 로그인 오류:', error)
       alert('소셜 로그인에 실패했습니다.')

--- a/src/pages/LoginLoadingPage.tsx
+++ b/src/pages/LoginLoadingPage.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+const LoginLoadingPage: React.FC = () => {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const token = params.get('token')
+
+    if (token) {
+      localStorage.setItem('accessToken', token)
+      console.log(token)
+      navigate('/')
+    } else {
+      console.error('토큰 없음')
+    }
+  }, [])
+
+  
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <p>로그인 중...</p>
+      <p className='mt-4'>곧 메인페이지로 이동됩니다.</p>
+    </div>
+  );
+};
+
+export default LoginLoadingPage


### PR DESCRIPTION
# [feat] 소셜로그인 API 연동 추가

## 😺 Issue
- #25 

## ✅ 작업 리스트
- 카카오 및 구글 로그인 API 연동
- 중간 토큰 저장하는 로딩페이지 추가

## ⚙️ 작업 내용
- 카카오 및 구글 로그인 백엔드로 리다이렉션
- 로그인 후 로딩페이지에서 토큰 저장 후 메인페이지로 리다이렉션

## 📷 테스트 / 구현 내용
![image](https://github.com/user-attachments/assets/7b9ca8d5-2062-48ee-a73d-9e0b7235a1f1)
