### PR TITLE
[fix] 밤하늘 페이지 ux 개선

### DIFF
--- a/src/pages/NightSkyPage.tsx
+++ b/src/pages/NightSkyPage.tsx
@@ -15,6 +15,7 @@ const NightSkyPage: React.FC = () => {
     newConcernTitle, //새로 작성할 고민 제목
     newConcernContent, //고민 내용
     newConcernCategory, //고민 카테고리리
+    pageInfo,
     setSelectedCategory,
     setIsModalOpen,
     setNewConcernTitle,
@@ -22,13 +23,14 @@ const NightSkyPage: React.FC = () => {
     setNewConcernCategory,
     resetForm,
     fetchConcerns,
+    setPage,
   } = useConcernStore()
 
   const navigate = useNavigate()
 
   useEffect(() => {
-    fetchConcerns()
-  }, [fetchConcerns])
+    fetchConcerns(pageInfo.number)
+  }, [fetchConcerns, pageInfo.number])
 
   const handleOpenModal = () => {
     setIsModalOpen(true)
@@ -46,6 +48,12 @@ const NightSkyPage: React.FC = () => {
 
   const handleCardClick = (id: number) => {
     navigate(`/night-sky/${id}`)
+  }
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 0 && newPage < pageInfo.totalPages) {
+      setPage(newPage)
+    }
   }
 
   return (
@@ -82,6 +90,37 @@ const NightSkyPage: React.FC = () => {
             />
           ))}
         </div>
+
+        {/* 페이징 UI */}
+        {!pageInfo.empty && (
+          <div className="flex justify-center items-center mt-8 gap-2">
+            <button
+              onClick={() => handlePageChange(pageInfo.number - 1)}
+              disabled={pageInfo.first}
+              className={`px-4 py-2 rounded-lg ${
+                pageInfo.first
+                  ? 'bg-gray-300 cursor-not-allowed'
+                  : 'bg-mainColor text-white hover:bg-opacity-90'
+              }`}
+            >
+              이전
+            </button>
+            <span className="mx-4">
+              {pageInfo.number + 1} / {pageInfo.totalPages}
+            </span>
+            <button
+              onClick={() => handlePageChange(pageInfo.number + 1)}
+              disabled={pageInfo.last}
+              className={`px-4 py-2 rounded-lg ${
+                pageInfo.last
+                  ? 'bg-gray-300 cursor-not-allowed'
+                  : 'bg-mainColor text-white hover:bg-opacity-90'
+              }`}
+            >
+              다음
+            </button>
+          </div>
+        )}
       </div>
 
       {isModalOpen && (


### PR DESCRIPTION
# [fix] 밤하늘 페이지 ux 개선

## 😺 Issue
- #42 

## ✅ 작업 리스트
- 페이징 처리 구현
- 카테고리 자동 설정 기능
- 데이터 구조 개선

## ⚙️ 작업 내용
-  밤하늘 페이지 페이징 처리 구현
     - API 엔드포인트 /api/boards/list에 페이지네이션 파라미터 추가
     - 페이지 정보를 저장할 PageInfo 인터페이스 추가
     - 페이지 변경 시 자동으로 데이터를 새로 불러오도록 useEffect 훅 수정

- 카테고리 자동 설정 기능
     - 카테고리 미선택 시 기존 학교에서 기본값으로 전체 카테고리가 선택되도록 하여 ux 개선
     - setSelectedCategory 함수 수정
     - setNewConcernCategory 함수 수정
     - resetForm 함수의 기본 카테고리 값을 전체로 변경

- 데이터 구조 개선
    - API 응답 구조에 맞게 데이터 타입을 정확하게 정의하여 타입 안정성 확보
    - Board 인터페이스에 사용자 정보 추가
    - Answer 인터페이스도 수정
    - 기타 함수 로직 리팩토링

## 📷 테스트 / 구현 내용
- 전체 조회시 프로필에 구글프사 적용, 답글 미리보기에 달토끼 대신 유저 닉네임 적용, 페이징 처리로 페이지 전환 가능
![image](https://github.com/user-attachments/assets/1254ad7e-7fce-4339-9ca9-ca3705c51d07)