### PR TITLE
[feat] 오늘의 질문 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import LoginSignupPage from './pages/LoginSignupPage'
 import NightSkyPage from './pages/NightSkyPage'
 import { NightSkyDetailPage } from './pages/NightSkyDetailPage'
 import ConstellationPage from './pages/ConstellationPage'
+import TodayQuestionPage from './pages/TodayQuestionPage'
 import Footer from './components/Footer'
 import LoginLoadingPage from './pages/LoginLoadingPage'
 import MypagePage from './pages/MypagePage'
@@ -45,6 +46,7 @@ function App() {
             element={<NightSkyDetailPage />}
           />
           <Route path="/stars" element={<ConstellationPage />} />
+          <Route path="/question" element={<TodayQuestionPage />} />
           <Route path="/mypage" element={<MypagePage />} />
         </Routes>
         <Footer />

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -25,6 +25,10 @@ export const ENDPOINTS = {
   // 플레이리스트(Playlist)
   PLAYLIST_LIST: `${BASE_URL}/playlists`,
 
+  // 오늘의 질문(Today Question)
+  TODAY_QUESTION: `${BASE_URL}/questions/today`,
+  QUESTION_ANSWER: (questionId: number) => `${BASE_URL}/questions/${questionId}/answer`,
+
   // 기타 필요시 추가
   ASSISTANT_ANSWER: (boardId: number, category: string) => `${BASE_URL}/board/${boardId}/assistant/${category}`,
 };

--- a/src/components/DesktopQuestionLayout.tsx
+++ b/src/components/DesktopQuestionLayout.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { QuestionCard as QuestionCardType } from '../types/questionCard'
+import QuestionCard from './QuestionCard'
+
+interface DesktopQuestionLayoutProps {
+  cards: QuestionCardType[]
+  likedCards: Set<number>
+  onLikeClick: (index: number) => void
+}
+
+const DesktopQuestionLayout: React.FC<DesktopQuestionLayoutProps> = ({
+  cards,
+  likedCards,
+  onLikeClick
+}) => {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 justify-items-center">
+      {cards.map((card, index) => (
+        <QuestionCard
+          key={index}
+          card={card}
+          index={index}
+          isLiked={likedCards.has(index)}
+          onLikeClick={onLikeClick}
+          isMobile={false}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default DesktopQuestionLayout

--- a/src/components/MobileQuestionLayout.tsx
+++ b/src/components/MobileQuestionLayout.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { QuestionCard as QuestionCardType } from '../types/questionCard'
+import QuestionCard from './QuestionCard'
+
+interface MobileQuestionLayoutProps {
+  cards: QuestionCardType[]
+  likedCards: Set<number>
+  onLikeClick: (index: number) => void
+}
+
+const MobileQuestionLayout: React.FC<MobileQuestionLayoutProps> = ({
+  cards,
+  likedCards,
+  onLikeClick
+}) => {
+  return (
+    <div className="space-y-6">
+      {cards.map((card, index) => (
+        <QuestionCard
+          key={index}
+          card={card}
+          index={index}
+          isLiked={likedCards.has(index)}
+          onLikeClick={onLikeClick}
+          isMobile={true}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default MobileQuestionLayout

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,14 +1,18 @@
 import React from 'react'
-import LogoImg from '../assets/images/MoonRabbitSleep2.png'
 
-const PageHeader: React.FC = () => {
+interface PageHeaderProps {
+  showSubtitle?: boolean
+  subtitleText?: string
+}
+
+const PageHeader: React.FC<PageHeaderProps> = ({ showSubtitle = true, subtitleText }) => {
   return (
     <div className="text-center mb-8 lg:mb-16">
       {/* 메인 이미지 */}
       <div className="mb-6 lg:mb-8">
         <img 
           className="w-48 h-40 lg:w-72 lg:h-64 mx-auto object-contain" 
-          src={LogoImg} 
+          src="/images/MoonRabbitSleep2.png" 
           alt="달토끼 로고"
         />
       </div>
@@ -20,9 +24,11 @@ const PageHeader: React.FC = () => {
       </div>
       
       {/* 서브 타이틀 */}
-      <div className="text-darkWalnut text-lg lg:text-xl xl:text-2xl font-normal font-mainFont max-w-4xl mx-auto leading-relaxed">
-        고민을 말하기도, 상담도 부담스럽다면 노래는 어때요?
-      </div>
+      {showSubtitle && (
+        <div className="text-darkWalnut text-lg lg:text-xl xl:text-2xl font-normal font-mainFont max-w-4xl mx-auto leading-relaxed">
+          {subtitleText ?? '고민을 말하기도, 상담도 부담스럽다면 노래는 어때요?'}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { QuestionCard as QuestionCardType } from '../types/questionCard'
+import Like from '../assets/images/Like.svg'
+import Liked from '../assets/images/Liked.svg'
+
+interface QuestionCardProps {
+  card: QuestionCardType
+  index: number
+  isLiked: boolean
+  onLikeClick: (index: number) => void
+  isMobile?: boolean
+}
+
+const QuestionCard: React.FC<QuestionCardProps> = ({
+  card,
+  index,
+  isLiked,
+  onLikeClick,
+  isMobile = false
+}) => {
+  const cardClasses = isMobile 
+    ? "relative overflow-hidden mx-auto flex flex-col bg-cover bg-center transition-transform duration-200 hover:translate-y-[-2px] max-w-full rounded-xl p-4"
+    : "relative overflow-hidden flex flex-col bg-cover bg-center transition-transform duration-200 hover:translate-y-[-2px] rounded-xl p-4 min-h-[140px] w-full min-w-[400px] max-w-[400px]"
+  
+  const textClasses = isMobile
+    ? "text-center text-darkWalnut text-lg font-normal font-mainFont whitespace-pre-line"
+    : "text-center text-darkWalnut text-xl lg:text-2xl font-normal font-mainFont whitespace-pre-line"
+  
+  const heartSize = isMobile ? "w-6 h-6" : "w-8 h-8"
+  const heartPosition = "absolute bottom-1 right-1 z-20"
+
+  return (
+    <div 
+      className={cardClasses}
+      style={{ 
+        backgroundImage: 'url("/images/ConcernBackground.png")',
+        boxShadow: 'rgb(71, 60, 44) 0px 0px 0px 2px inset'
+      }}
+    >
+      <div className="relative z-10 w-full h-full flex items-center justify-center">
+        <div className={textClasses}>
+          {card.content}
+        </div>
+      </div>
+      
+      {/* 하트 좋아요 버튼 */}
+      <div className={heartPosition}>
+        <button
+          onClick={() => onLikeClick(index)}
+          className="p-2 rounded-full transition-colors duration-200"
+        >
+          <img
+            src={isLiked ? Liked : Like}
+            alt="좋아요"
+            className={`${heartSize} cursor-pointer`}
+          />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default QuestionCard

--- a/src/hooks/useQuestionCards.ts
+++ b/src/hooks/useQuestionCards.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect } from 'react'
+import axios from 'axios'
+import { ENDPOINTS } from '../api/endpoints'
+import { Question } from '../types/question'
+import { mockQuestionCards } from '../types/questionCard'
+
+export const useQuestionCards = () => {
+  const [todayQuestion, setTodayQuestion] = useState<Question | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [likedCards, setLikedCards] = useState<Set<number>>(new Set())
+
+  useEffect(() => {
+    const fetchTodayQuestion = async () => {
+      try {
+        const response = await axios.get(ENDPOINTS.TODAY_QUESTION)
+        setTodayQuestion(response.data)
+      } catch (error) {
+        console.error('오늘의 질문 조회 실패:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchTodayQuestion()
+  }, [])
+
+  const handleLikeClick = (cardIndex: number) => {
+    if (likedCards.has(cardIndex)) {
+      setLikedCards(prev => {
+        const newSet = new Set([...prev])
+        newSet.delete(cardIndex)
+        return newSet
+      })
+    } else {
+      setLikedCards(prev => new Set([...prev, cardIndex]))
+    }
+  }
+
+  return {
+    todayQuestion,
+    loading,
+    likedCards,
+    handleLikeClick,
+    questionCards: mockQuestionCards
+  }
+}

--- a/src/pages/TodayQuestionPage.tsx
+++ b/src/pages/TodayQuestionPage.tsx
@@ -23,7 +23,7 @@ const TodayQuestionPage: React.FC = () => {
       <StarBackground isMobile={isMobile} />
 
       <div className="container mx-auto px-4 py-8 lg:py-16">
-        <PageHeader />
+        <PageHeader showSubtitle={false} />
         
         {/* 오늘의 질문 */}
         <div className="text-center mb-8 lg:mb-16">

--- a/src/pages/TodayQuestionPage.tsx
+++ b/src/pages/TodayQuestionPage.tsx
@@ -1,72 +1,32 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { useResponsiveStore } from '../stores/useResponsiveStore'
+import { useQuestionCards } from '../hooks/useQuestionCards'
 import StarBackground from '../components/StarBackground'
-import LogoImg from '../assets/images/MoonRabbitSleep2.png'
-import Like from '../assets/images/Like.svg'
-import Liked from '../assets/images/Liked.svg'
-import axios from 'axios'
-import { ENDPOINTS } from '../api/endpoints'
-import { Question } from '../types/question'
+import PageHeader from '../components/PageHeader'
+import MobileQuestionLayout from '../components/MobileQuestionLayout'
+import DesktopQuestionLayout from '../components/DesktopQuestionLayout'
 
 const TodayQuestionPage: React.FC = () => {
   const { res } = useResponsiveStore()
   const isMobile = res === 'mo'
   
-  const [todayQuestion, setTodayQuestion] = useState<Question | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [likedCards, setLikedCards] = useState<Set<number>>(new Set())
-
-  useEffect(() => {
-    const fetchTodayQuestion = async () => {
-      try {
-        const response = await axios.get(ENDPOINTS.TODAY_QUESTION)
-        setTodayQuestion(response.data)
-      } catch (error) {
-        console.error('오늘의 질문 조회 실패:', error)
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchTodayQuestion()
-  }, [])
-
-  const handleLikeClick = (cardIndex: number) => {
-    // 좋아요 토글
-    if (likedCards.has(cardIndex)) {
-      setLikedCards(prev => {
-        const newSet = new Set([...prev])
-        newSet.delete(cardIndex)
-        return newSet
-      })
-    } else {
-      setLikedCards(prev => new Set([...prev, cardIndex]))
-    }
-  }
+  const { 
+    todayQuestion, 
+    loading, 
+    likedCards, 
+    handleLikeClick, 
+    questionCards 
+  } = useQuestionCards()
 
   return (
     <div className="min-h-screen bg-lightBeige relative overflow-hidden">
       <StarBackground isMobile={isMobile} />
 
       <div className="container mx-auto px-4 py-8 lg:py-16">
-        {/* 헤더 섹션 */}
+        <PageHeader />
+        
+        {/* 오늘의 질문 */}
         <div className="text-center mb-8 lg:mb-16">
-          {/* 메인 이미지 */}
-          <div className="mb-6 lg:mb-8">
-            <img 
-              className="w-48 h-40 lg:w-72 lg:h-64 mx-auto object-contain" 
-              src={LogoImg} 
-              alt="달토끼 로고"
-            />
-          </div>
-          
-          {/* 메인 타이틀 */}
-          <div className="mb-4 lg:mb-6">
-            <span className="text-lightCaramel text-3xl lg:text-5xl font-normal font-mainFont">달</span>
-            <span className="text-darkWalnut text-3xl lg:text-5xl font-normal font-mainFont">토끼</span>
-          </div>
-          
-          {/* 오늘의 질문 */}
           <div className="text-darkWalnut text-lg lg:text-2xl xl:text-3xl font-normal font-mainFont max-w-4xl mx-auto leading-relaxed">
             {loading ? "질문을 불러오는 중..." : (todayQuestion?.content || "자신만의 스트레스 해소법은 뭔가요?")}
           </div>
@@ -75,96 +35,17 @@ const TodayQuestionPage: React.FC = () => {
         {/* 질문답변 카드 섹션 */}
         <div className="mb-8 relative z-10">
           {isMobile ? (
-            /* 모바일 레이아웃 */
-            <div className="space-y-6">
-              {[
-                { type: 'text', content: '카페에서 노트북으로 넷플릭스 봐요 ☕️' },
-                { type: 'challenge', content: '3일 동안 SNS 안 하기 📵' },
-                { type: 'support', content: '나만 힘든 거 아니구나 싶어서 위로가 돼요 🌙' },
-                { type: 'text', content: '런닝하고 샤워하면 고민이 다 날아가더라구요 🏃‍♂️' },
-                { type: 'quote', content: '노래방에서 말달리자 3번 부르기' },
-                { type: 'confession', content: '요즘 너무 외로워서 누군가랑 대화만 해도 좋을 것 같아요 🥲' }
-              ].map((item, index) => {
-                const isLiked = likedCards.has(index)
-                return (
-                  <div 
-                    key={index}
-                    className="relative overflow-hidden mx-auto flex flex-col bg-cover bg-center transition-transform duration-200 hover:translate-y-[-2px] max-w-full rounded-xl p-4"
-                    style={{ 
-                      backgroundImage: 'url("/images/ConcernBackground.png")',
-                      boxShadow: 'rgb(71, 60, 44) 0px 0px 0px 2px inset'
-                    }}
-                  >
-                    <div className="relative z-10 w-full h-full flex items-center justify-center">
-                      <div className="text-center text-darkWalnut text-lg font-normal font-mainFont whitespace-pre-line">
-                        {item.content}
-                      </div>
-                    </div>
-                    
-                    {/* 하트 좋아요 버튼 */}
-                    <div className="absolute bottom-1 right-1 z-20">
-                      <button
-                        onClick={() => handleLikeClick(index)}
-                        className="p-2 rounded-full transition-colors duration-200"
-                      >
-                        <img
-                          src={isLiked ? Liked : Like}
-                          alt="좋아요"
-                          className="w-6 h-6 cursor-pointer"
-                        />
-                      </button>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
+            <MobileQuestionLayout
+              cards={questionCards}
+              likedCards={likedCards}
+              onLikeClick={handleLikeClick}
+            />
           ) : (
-            /* 데스크톱 레이아웃 */
-            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 justify-items-center">
-              {[
-                { type: 'text', content: '카페에서 노트북으로 넷플릭스 봐요 ☕️' },
-                { type: 'challenge', content: '3일 동안 SNS 안 하기 📵' },
-                { type: 'support', content: '나만 힘든 거 아니구나 싶어서 위로가 돼요 🌙' },
-                { type: 'text', content: '런닝하고 샤워하면 고민이 다 날아가더라구요 🏃‍♂️' },
-                { type: 'quote', content: '노래방에서 말달리자 3번 부르기' },
-                { type: 'confession', content: '요즘 너무 외로워서 누군가랑 대화만 해도 좋을 것 같아요 🥲' },
-                { type: 'challenge', content: '낯선 사람에게 하루에 한 번 미소 짓기 😀' },
-                { type: 'text', content: '음악 들으면서 그림 그리는 시간이 최고예요 🎨' },
-                { type: 'support', content: '모든 게 완벽하지 않아도 괜찮다는 걸 배웠어요 💝' }
-              ].map((item, index) => {
-                const isLiked = likedCards.has(index)
-                return (
-                  <div 
-                    key={index}
-                    className="relative overflow-hidden flex flex-col bg-cover bg-center transition-transform duration-200 hover:translate-y-[-2px] rounded-xl p-4 min-h-[140px] w-full min-w-[400px] max-w-[400px]"
-                    style={{ 
-                      backgroundImage: 'url("/images/ConcernBackground.png")',
-                      boxShadow: 'rgb(71, 60, 44) 0px 0px 0px 2px inset'
-                    }}
-                  >
-                    <div className="relative z-10 w-full h-full flex items-center justify-center">
-                      <div className="text-center text-darkWalnut text-xl lg:text-2xl font-normal font-mainFont whitespace-pre-line">
-                        {item.content}
-                      </div>
-                    </div>
-                    
-                    {/* 하트 좋아요 버튼 */}
-                    <div className="absolute bottom-1 right-1 z-20">
-                      <button
-                        onClick={() => handleLikeClick(index)}
-                        className="p-3 rounded-full transition-colors duration-200"
-                      >
-                        <img
-                          src={isLiked ? Liked : Like}
-                          alt="좋아요"
-                          className="w-8 h-8 cursor-pointer"
-                        />
-                      </button>
-                    </div>
-                  </div>
-                )
-              })}
-            </div>
+            <DesktopQuestionLayout
+              cards={questionCards}
+              likedCards={likedCards}
+              onLikeClick={handleLikeClick}
+            />
           )}
         </div>
       </div>

--- a/src/pages/TodayQuestionPage.tsx
+++ b/src/pages/TodayQuestionPage.tsx
@@ -78,12 +78,12 @@ const TodayQuestionPage: React.FC = () => {
             /* 모바일 레이아웃 */
             <div className="space-y-6">
               {[
-                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
-                { type: 'challenge', content: '노래방가서 말달리자\n연속3번 부르기', placeholder: '도전 후기를 남겨주세요...' },
-                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
-                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
-                { type: 'challenge', content: '노래방가서 말달리자\n연속3번 부르기', placeholder: '도전 후기를 남겨주세요...' },
-                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' }
+                { type: 'text', content: '카페에서 노트북으로 넷플릭스 봐요 ☕️' },
+                { type: 'challenge', content: '3일 동안 SNS 안 하기 📵' },
+                { type: 'support', content: '나만 힘든 거 아니구나 싶어서 위로가 돼요 🌙' },
+                { type: 'text', content: '런닝하고 샤워하면 고민이 다 날아가더라구요 🏃‍♂️' },
+                { type: 'quote', content: '노래방에서 말달리자 3번 부르기' },
+                { type: 'confession', content: '요즘 너무 외로워서 누군가랑 대화만 해도 좋을 것 같아요 🥲' }
               ].map((item, index) => {
                 const isLiked = likedCards.has(index)
                 return (
@@ -102,7 +102,7 @@ const TodayQuestionPage: React.FC = () => {
                     </div>
                     
                     {/* 하트 좋아요 버튼 */}
-                    <div className="absolute bottom-3 right-3 z-20">
+                    <div className="absolute bottom-1 right-1 z-20">
                       <button
                         onClick={() => handleLikeClick(index)}
                         className="p-2 rounded-full transition-colors duration-200"
@@ -122,15 +122,15 @@ const TodayQuestionPage: React.FC = () => {
             /* 데스크톱 레이아웃 */
             <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 justify-items-center">
               {[
-                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
-                { type: 'challenge', content: '노래방가서 말달리자\n연속3번 부르기', placeholder: '도전 후기를 남겨주세요...' },
-                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
-                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
-                { type: 'challenge', content: '노래방가서 말달리자\n연속3번 부르기', placeholder: '도전 후기를 남겨주세요...' },
-                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
-                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
-                { type: 'challenge', content: '노래방가서 말달리자\n연속3번 부르기', placeholder: '도전 후기를 남겨주세요...' },
-                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' }
+                { type: 'text', content: '카페에서 노트북으로 넷플릭스 봐요 ☕️' },
+                { type: 'challenge', content: '3일 동안 SNS 안 하기 📵' },
+                { type: 'support', content: '나만 힘든 거 아니구나 싶어서 위로가 돼요 🌙' },
+                { type: 'text', content: '런닝하고 샤워하면 고민이 다 날아가더라구요 🏃‍♂️' },
+                { type: 'quote', content: '노래방에서 말달리자 3번 부르기' },
+                { type: 'confession', content: '요즘 너무 외로워서 누군가랑 대화만 해도 좋을 것 같아요 🥲' },
+                { type: 'challenge', content: '낯선 사람에게 하루에 한 번 미소 짓기 😀' },
+                { type: 'text', content: '음악 들으면서 그림 그리는 시간이 최고예요 🎨' },
+                { type: 'support', content: '모든 게 완벽하지 않아도 괜찮다는 걸 배웠어요 💝' }
               ].map((item, index) => {
                 const isLiked = likedCards.has(index)
                 return (
@@ -149,7 +149,7 @@ const TodayQuestionPage: React.FC = () => {
                     </div>
                     
                     {/* 하트 좋아요 버튼 */}
-                    <div className="absolute bottom-4 right-4 z-20">
+                    <div className="absolute bottom-1 right-1 z-20">
                       <button
                         onClick={() => handleLikeClick(index)}
                         className="p-3 rounded-full transition-colors duration-200"

--- a/src/pages/TodayQuestionPage.tsx
+++ b/src/pages/TodayQuestionPage.tsx
@@ -1,0 +1,175 @@
+import React, { useState, useEffect } from 'react'
+import { useResponsiveStore } from '../stores/useResponsiveStore'
+import StarBackground from '../components/StarBackground'
+import LogoImg from '../assets/images/MoonRabbitSleep2.png'
+import Like from '../assets/images/Like.svg'
+import Liked from '../assets/images/Liked.svg'
+import axios from 'axios'
+import { ENDPOINTS } from '../api/endpoints'
+import { Question } from '../types/question'
+
+const TodayQuestionPage: React.FC = () => {
+  const { res } = useResponsiveStore()
+  const isMobile = res === 'mo'
+  
+  const [todayQuestion, setTodayQuestion] = useState<Question | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [likedCards, setLikedCards] = useState<Set<number>>(new Set())
+
+  useEffect(() => {
+    const fetchTodayQuestion = async () => {
+      try {
+        const response = await axios.get(ENDPOINTS.TODAY_QUESTION)
+        setTodayQuestion(response.data)
+      } catch (error) {
+        console.error('오늘의 질문 조회 실패:', error)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    fetchTodayQuestion()
+  }, [])
+
+  const handleLikeClick = (cardIndex: number) => {
+    // 좋아요 토글
+    if (likedCards.has(cardIndex)) {
+      setLikedCards(prev => {
+        const newSet = new Set([...prev])
+        newSet.delete(cardIndex)
+        return newSet
+      })
+    } else {
+      setLikedCards(prev => new Set([...prev, cardIndex]))
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-lightBeige relative overflow-hidden">
+      <StarBackground isMobile={isMobile} />
+
+      <div className="container mx-auto px-4 py-8 lg:py-16">
+        {/* 헤더 섹션 */}
+        <div className="text-center mb-8 lg:mb-16">
+          {/* 메인 이미지 */}
+          <div className="mb-6 lg:mb-8">
+            <img 
+              className="w-48 h-40 lg:w-72 lg:h-64 mx-auto object-contain" 
+              src={LogoImg} 
+              alt="달토끼 로고"
+            />
+          </div>
+          
+          {/* 메인 타이틀 */}
+          <div className="mb-4 lg:mb-6">
+            <span className="text-lightCaramel text-3xl lg:text-5xl font-normal font-mainFont">달</span>
+            <span className="text-darkWalnut text-3xl lg:text-5xl font-normal font-mainFont">토끼</span>
+          </div>
+          
+          {/* 오늘의 질문 */}
+          <div className="text-darkWalnut text-lg lg:text-2xl xl:text-3xl font-normal font-mainFont max-w-4xl mx-auto leading-relaxed">
+            {loading ? "질문을 불러오는 중..." : (todayQuestion?.content || "자신만의 스트레스 해소법은 뭔가요?")}
+          </div>
+        </div>
+
+        {/* 질문답변 카드 섹션 */}
+        <div className="mb-8 relative z-10">
+          {isMobile ? (
+            /* 모바일 레이아웃 */
+            <div className="space-y-6">
+              {[
+                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
+                { type: 'challenge', content: '노래방가서 말달리자\n연속3번 부르기', placeholder: '도전 후기를 남겨주세요...' },
+                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
+                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
+                { type: 'challenge', content: '노래방가서 말달리자\n연속3번 부르기', placeholder: '도전 후기를 남겨주세요...' },
+                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' }
+              ].map((item, index) => {
+                const isLiked = likedCards.has(index)
+                return (
+                  <div 
+                    key={index}
+                    className="relative overflow-hidden mx-auto flex flex-col bg-cover bg-center transition-transform duration-200 hover:translate-y-[-2px] max-w-full rounded-xl p-4"
+                    style={{ 
+                      backgroundImage: 'url("/images/ConcernBackground.png")',
+                      boxShadow: 'rgb(71, 60, 44) 0px 0px 0px 2px inset'
+                    }}
+                  >
+                    <div className="relative z-10 w-full h-full flex items-center justify-center">
+                      <div className="text-center text-darkWalnut text-lg font-normal font-mainFont whitespace-pre-line">
+                        {item.content}
+                      </div>
+                    </div>
+                    
+                    {/* 하트 좋아요 버튼 */}
+                    <div className="absolute bottom-3 right-3 z-20">
+                      <button
+                        onClick={() => handleLikeClick(index)}
+                        className="p-2 rounded-full transition-colors duration-200"
+                      >
+                        <img
+                          src={isLiked ? Liked : Like}
+                          alt="좋아요"
+                          className="w-6 h-6 cursor-pointer"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          ) : (
+            /* 데스크톱 레이아웃 */
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 justify-items-center">
+              {[
+                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
+                { type: 'challenge', content: '노래방가서 말달리자\n연속3번 부르기', placeholder: '도전 후기를 남겨주세요...' },
+                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
+                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
+                { type: 'challenge', content: '노래방가서 말달리자\n연속3번 부르기', placeholder: '도전 후기를 남겨주세요...' },
+                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
+                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' },
+                { type: 'challenge', content: '노래방가서 말달리자\n연속3번 부르기', placeholder: '도전 후기를 남겨주세요...' },
+                { type: 'text', content: '질문답변', placeholder: '답변을 입력해주세요...' }
+              ].map((item, index) => {
+                const isLiked = likedCards.has(index)
+                return (
+                  <div 
+                    key={index}
+                    className="relative overflow-hidden flex flex-col bg-cover bg-center transition-transform duration-200 hover:translate-y-[-2px] rounded-xl p-4 min-h-[140px] w-full min-w-[400px] max-w-[400px]"
+                    style={{ 
+                      backgroundImage: 'url("/images/ConcernBackground.png")',
+                      boxShadow: 'rgb(71, 60, 44) 0px 0px 0px 2px inset'
+                    }}
+                  >
+                    <div className="relative z-10 w-full h-full flex items-center justify-center">
+                      <div className="text-center text-darkWalnut text-xl lg:text-2xl font-normal font-mainFont whitespace-pre-line">
+                        {item.content}
+                      </div>
+                    </div>
+                    
+                    {/* 하트 좋아요 버튼 */}
+                    <div className="absolute bottom-4 right-4 z-20">
+                      <button
+                        onClick={() => handleLikeClick(index)}
+                        className="p-3 rounded-full transition-colors duration-200"
+                      >
+                        <img
+                          src={isLiked ? Liked : Like}
+                          alt="좋아요"
+                          className="w-8 h-8 cursor-pointer"
+                        />
+                      </button>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default TodayQuestionPage

--- a/src/types/question.ts
+++ b/src/types/question.ts
@@ -1,0 +1,18 @@
+export interface Question {
+  id: number
+  content: string
+  createdAt: string
+  isAnswered?: boolean
+}
+
+export interface Answer {
+  id: number
+  questionId: number
+  content: string
+  createdAt: string
+}
+
+export interface QuestionAnswer {
+  question: Question
+  answer?: Answer
+}

--- a/src/types/questionCard.ts
+++ b/src/types/questionCard.ts
@@ -1,0 +1,18 @@
+export type QuestionCardType = 'text' | 'challenge' | 'support' | 'quote' | 'confession'
+
+export interface QuestionCard {
+  type: QuestionCardType
+  content: string
+}
+
+export const mockQuestionCards: QuestionCard[] = [
+  { type: 'text', content: '카페에서 노트북으로 넷플릭스 봐요 ☕️' },
+  { type: 'challenge', content: '3일 동안 SNS 안 하기 📵' },
+  { type: 'support', content: '나만 힘든 거 아니구나 싶어서 위로가 돼요 🌙' },
+  { type: 'text', content: '런닝하고 샤워하면 고민이 다 날아가더라구요 🏃‍♂️' },
+  { type: 'quote', content: '노래방에서 말달리자 3번 부르기' },
+  { type: 'confession', content: '요즘 너무 외로워서 누군가랑 대화만 해도 좋을 것 같아요 🥲' },
+  { type: 'challenge', content: '낯선 사람에게 하루에 한 번 미소 짓기 😀' },
+  { type: 'text', content: '음악 들으면서 그림 그리는 시간이 최고예요 🎨' },
+  { type: 'support', content: '모든 게 완벽하지 않아도 괜찮다는 걸 배웠어요 💝' }
+]


### PR DESCRIPTION
# [feat] 오늘의 질문 UI 구현

## 😺 Issue
- #49 

## ✅ 작업 리스트
- 기존 질문 배경, 하트 기반으로 오늘의 질문 답변 UI 생성
- 질문 카드 컴포넌트화 및 레이아웃 분리

## ⚙️ 작업 내용
- 오늘의 질문 페이지에서 질문 문구 표시, 카드 UI, 좋아요 토글, 배경/그림자/호버 효과를 구현 및 상태 로직 분리 진행

## 📷 테스트 / 구현 내용
<img width="2940" height="1752" alt="image" src="https://github.com/user-attachments/assets/c6fb7075-ae26-458f-9605-cbf77aa37a33" />

<img width="818" height="1534" alt="image" src="https://github.com/user-attachments/assets/5d46967b-0c7d-413f-8f03-84bc7e6b99a0" />
