### PR TITLE
[refactor] 상점 관련 UX 개선

### DIFF
--- a/src/features/mypage/components/NicknameColorModal.tsx
+++ b/src/features/mypage/components/NicknameColorModal.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { X, ChevronLeft, ChevronRight } from 'lucide-react'
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useEffect } from 'react'
 
 import MiniModal from '@/common/components/MiniModal'
 import { NICKNAME_COLOR_DEFINITIONS } from '@/common/constants/colors'
@@ -25,7 +25,15 @@ const NicknameColorModal: React.FC<NicknameColorModalProps> = ({
 
   const { getItemsByType, loading } = useShopStore()
   const apiNicknameColorItems = getItemsByType('NAME_COLOR')
-  const { userInventory } = useUserProfileStore()
+  const { userInventory, userProfile, fetchUserInventory } =
+    useUserProfileStore()
+
+  // 모달이 열릴 때 인벤토리 로드
+  useEffect(() => {
+    if (isOpen && userProfile?.id) {
+      fetchUserInventory(userProfile.id)
+    }
+  }, [isOpen, userProfile?.id, fetchUserInventory])
 
   // 공통 구매 로직 훅 사용
   const { purchasingItemId, miniModal, handlePurchaseClick, closeMiniModal } =
@@ -137,7 +145,7 @@ const NicknameColorModal: React.FC<NicknameColorModalProps> = ({
                 {/* 색상 카드 */}
                 <div
                   className={clsx(
-                    'rounded-[10px] border-[3px] border-mainColor p-4 mb-4 flex flex-col items-center',
+                    'p-4 mb-4 flex flex-col items-center',
                     isMobile ? 'w-full' : 'w-52 h-56',
                   )}
                 >

--- a/src/features/shop/components/BannerShopModal.tsx
+++ b/src/features/shop/components/BannerShopModal.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { X, ChevronLeft, ChevronRight } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import MiniModal from '@/common/components/MiniModal'
 import { useResponsiveStore } from '@/common/hooks/useResponsiveStore'
@@ -24,7 +24,15 @@ const BannerShopModal: React.FC<BannerShopModalProps> = ({
 
   const { getItemsByType, loading } = useShopStore()
   const bannerItems = getItemsByType('BANNER')
-  const { userInventory } = useUserProfileStore()
+  const { userInventory, userProfile, fetchUserInventory } =
+    useUserProfileStore()
+
+  // 모달이 열릴 때 인벤토리 로드
+  useEffect(() => {
+    if (isOpen && userProfile?.id) {
+      fetchUserInventory(userProfile.id)
+    }
+  }, [isOpen, userProfile?.id, fetchUserInventory])
 
   // 공통 구매 로직 훅 사용
   const { purchasingItemId, miniModal, handlePurchaseClick, closeMiniModal } =

--- a/src/features/shop/components/BorderShopModal.tsx
+++ b/src/features/shop/components/BorderShopModal.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { X, ChevronLeft, ChevronRight } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import MiniModal from '@/common/components/MiniModal'
 import { useResponsiveStore } from '@/common/hooks/useResponsiveStore'
@@ -24,7 +24,15 @@ const BorderShopModal: React.FC<BorderShopModalProps> = ({
 
   const { getItemsByType, loading } = useShopStore()
   const borderItems = getItemsByType('BORDER')
-  const { userInventory } = useUserProfileStore()
+  const { userInventory, userProfile, fetchUserInventory } =
+    useUserProfileStore()
+
+  // 모달이 열릴 때 인벤토리 로드
+  useEffect(() => {
+    if (isOpen && userProfile?.id) {
+      fetchUserInventory(userProfile.id)
+    }
+  }, [isOpen, userProfile?.id, fetchUserInventory])
 
   // 공통 구매 로직 훅 사용
   const { purchasingItemId, miniModal, handlePurchaseClick, closeMiniModal } =

--- a/src/features/shop/hooks/useShopPurchase.ts
+++ b/src/features/shop/hooks/useShopPurchase.ts
@@ -33,11 +33,12 @@ export const useShopPurchase = () => {
 
     // 포인트 부족 체크
     if (userProfile && userProfile.point < itemPrice) {
+      const shortage = itemPrice - userProfile.point
       setMiniModal({
         isOpen: true,
         type: 'error',
         title: '포인트 부족',
-        message: '포인트가 부족합니다.',
+        message: `포인트가 ${shortage}포인트 부족합니다.`,
       })
       return
     }

--- a/src/pages/ShopPage.tsx
+++ b/src/pages/ShopPage.tsx
@@ -8,6 +8,7 @@ import PageHeader from '@/common/components/PageHeader'
 import StarBackground from '@/common/components/StarBackground'
 import { useResponsiveStore } from '@/common/hooks/useResponsiveStore'
 import NicknameColorModal from '@/features/mypage/components/NicknameColorModal'
+import { useUserProfileStore } from '@/features/mypage/stores/useUserProfileStore'
 import BannerShopModal from '@/features/shop/components/BannerShopModal'
 import BorderShopModal from '@/features/shop/components/BorderShopModal'
 import { useShopStore } from '@/features/shop/stores/useShopStore'
@@ -21,10 +22,12 @@ const ShopPage: React.FC = memo(() => {
     useState(false)
 
   const { fetchShopItems } = useShopStore()
+  const { userProfile, fetchUserProfile } = useUserProfileStore()
 
   useEffect(() => {
     fetchShopItems()
-  }, [fetchShopItems])
+    fetchUserProfile()
+  }, [fetchShopItems, fetchUserProfile])
 
   const shopItems = [
     {
@@ -59,6 +62,25 @@ const ShopPage: React.FC = memo(() => {
 
       <div className="container mx-auto px-4 py-8 lg:py-16 relative z-10">
         <PageHeader showSubtitle={true} subtitleText="상점" />
+
+        {/* 보유 포인트 표시 */}
+        <div className="flex justify-center mb-8">
+          <div className="relative flex items-center">
+            <img
+              src="/images/point.png"
+              alt="포인트"
+              className={clsx(isMobile ? 'w-16 h-8' : 'w-20 h-10')}
+            />
+            <span
+              className={clsx(
+                'absolute ml-5 inset-0 flex items-center justify-center font-mainFont text-darkWalnut font-bold',
+                isMobile ? 'text-base' : 'text-lg',
+              )}
+            >
+              {userProfile?.point !== undefined ? userProfile.point : 0}
+            </span>
+          </div>
+        </div>
 
         {/* 상품 그리드 */}
         <div


### PR DESCRIPTION
# [refactor] 상점 관련 UX 개선

## 😺 Issue
- #102 

## ✅ 작업 리스트
- 상점에서 보유 포인트 표시
- 구매 시도시 몇 포인트가 부족한지 알려주는 처리

## ⚙️ 작업 내용
- 상점 페이지에 보유 포인트 표시
- 구매 시도 할 떄 포인트 부족 시 미니모달 알림
- 보유 아이템은 버튼 비활성화 작업 해뒀던거에서 상점 페이지에서 다른 페이지 강제이동(주소창으로)하면 보유 아이템 인식 못하는 오류가 있었어서 기존 상점페이지에서 유저 인벤토리 로드 로직에서 모달 열 때 사용자 인벤토리 로드 로직으로 수정

## 📷 테스트 / 구현 내용
<img width="2940" height="1660" alt="image" src="https://github.com/user-attachments/assets/14345019-7441-419f-9839-daf10335a4d1" />

<img width="2940" height="1654" alt="image" src="https://github.com/user-attachments/assets/95ef4a83-4620-417c-8118-5bcf3fa98dae" />